### PR TITLE
feat: phase 6 implemented

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/splitit/domain/service/BalanceCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/splitit/domain/service/BalanceCalculator.kt
@@ -12,8 +12,17 @@ class BalanceCalculator {
         participants: List<Participant>,
         expenses: List<Expense>,
     ): List<Balance> {
+        require(participants.map { it.id }.toSet().size == participants.size) {
+            "Session participants cannot contain duplicate IDs."
+        }
+
+        val currencyCode = defaultCurrency(expenses)
+        require(expenses.all { it.amount.currencyCode == currencyCode }) {
+            "All expenses in a session must use the same currency."
+        }
+
         val balances = participants.associate { participant ->
-            participant.id to Money.zero(defaultCurrency(expenses))
+            participant.id to Money.zero(currencyCode)
         }.toMutableMap()
 
         expenses.forEach { expense ->
@@ -38,6 +47,17 @@ class BalanceCalculator {
     }
 
     fun calculateDebts(balances: List<Balance>): List<Debt> {
+        if (balances.isEmpty()) return emptyList()
+
+        val currencyCode = balances.first().amount.currencyCode
+        require(balances.all { it.amount.currencyCode == currencyCode }) {
+            "All balances must use the same currency."
+        }
+        val total = balances.fold(Money.zero(currencyCode)) { sum, balance ->
+            sum + balance.amount
+        }
+        require(total.isZero()) { "Balances must sum to zero before debts are calculated." }
+
         val debtors = balances
             .filter { it.amount.minorUnits < 0 }
             .map { it.participantId to -it.amount }
@@ -73,23 +93,46 @@ class BalanceCalculator {
     }
 
     private fun splitExpense(expense: Expense): Map<ParticipantId, Money> {
-        val totalWeight = expense.participantShares.sumOf { it.shareWeight }
-        var allocated = 0L
+        val shares = expense.participantShares.sortedBy { it.participantId.value }
+        val totalWeight = shares.sumOf { it.shareWeight.toLong() }
+        val amount = expense.amount.minorUnits
+        val baseQuotient = amount / totalWeight
+        val amountRemainder = amount % totalWeight
+        val allocations = shares.map { share ->
+            val weightedRemainder = amountRemainder * share.shareWeight
+            Allocation(
+                participantId = share.participantId,
+                minorUnits = baseQuotient * share.shareWeight + weightedRemainder / totalWeight,
+                remainder = weightedRemainder % totalWeight,
+            )
+        }
 
-        return expense.participantShares
-            .sortedBy { it.participantId.value }
-            .mapIndexed { index, share ->
-                val isLast = index == expense.participantShares.lastIndex
-                val minorUnits = if (isLast) {
-                    expense.amount.minorUnits - allocated
-                } else {
-                    (expense.amount.minorUnits * share.shareWeight) / totalWeight
-                }
-                allocated += minorUnits
-                share.participantId to Money(minorUnits, expense.amount.currencyCode)
-            }
-            .toMap()
+        var remainingMinorUnits = amount - allocations.sumOf { it.minorUnits }
+        val roundedUpParticipantIds = allocations
+            .sortedWith(compareByDescending<Allocation> { it.remainder }.thenBy { it.participantId.value })
+            .map { it.participantId }
+        val roundedMinorUnits = allocations.associate { it.participantId to it.minorUnits }.toMutableMap()
+
+        for (participantId in roundedUpParticipantIds) {
+            if (remainingMinorUnits == 0L) break
+            roundedMinorUnits[participantId] = roundedMinorUnits.getValue(participantId) + 1
+            remainingMinorUnits--
+        }
+
+        check(remainingMinorUnits == 0L) { "Expense split failed to allocate all minor units." }
+        return shares.associate { share ->
+            share.participantId to Money(
+                minorUnits = roundedMinorUnits.getValue(share.participantId),
+                currencyCode = expense.amount.currencyCode,
+            )
+        }
     }
+
+    private data class Allocation(
+        val participantId: ParticipantId,
+        val minorUnits: Long,
+        val remainder: Long,
+    )
 
     private fun defaultCurrency(expenses: List<Expense>): String {
         return expenses.firstOrNull()?.amount?.currencyCode ?: "USD"

--- a/composeApp/src/commonTest/kotlin/com/example/splitit/domain/service/BalanceCalculatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/example/splitit/domain/service/BalanceCalculatorTest.kt
@@ -1,5 +1,6 @@
 package com.example.splitit.domain.service
 
+import com.example.splitit.domain.model.Balance
 import com.example.splitit.domain.model.Expense
 import com.example.splitit.domain.model.ExpenseParticipantShare
 import com.example.splitit.domain.model.Participant
@@ -9,6 +10,7 @@ import com.example.splitit.domain.value.ParticipantId
 import com.example.splitit.domain.value.SessionId
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class BalanceCalculatorTest {
     private val calculator = BalanceCalculator()
@@ -75,6 +77,111 @@ class BalanceCalculatorTest {
         assertEquals(charlieId, debts.first().fromParticipantId)
         assertEquals(aliceId, debts.first().toParticipantId)
         assertEquals(Money(600, "USD"), debts.first().amount)
+    }
+
+    @Test
+    fun calculateBalancesWhenPayerIsNotIncluded() {
+        val expense = expense(
+            amount = 1200,
+            payerId = aliceId,
+            participantIds = listOf(bobId, charlieId),
+        )
+
+        val balances = calculator.calculateBalances(participants, listOf(expense))
+            .associate { it.participantId to it.amount.minorUnits }
+
+        assertEquals(1200, balances.getValue(aliceId))
+        assertEquals(-600, balances.getValue(bobId))
+        assertEquals(-600, balances.getValue(charlieId))
+        assertEquals(0, balances.values.sum())
+    }
+
+    @Test
+    fun distributesRemainderByLargestFractionAndStableParticipantId() {
+        val expense = expense(
+            amount = 100,
+            payerId = aliceId,
+            participantIds = listOf(charlieId, bobId, aliceId),
+        )
+
+        val balances = calculator.calculateBalances(participants, listOf(expense))
+            .associate { it.participantId to it.amount.minorUnits }
+
+        // The extra minor unit goes to Alice because equal remainders use ID order.
+        assertEquals(66, balances.getValue(aliceId))
+        assertEquals(-33, balances.getValue(bobId))
+        assertEquals(-33, balances.getValue(charlieId))
+        assertEquals(0, balances.values.sum())
+    }
+
+    @Test
+    fun weightedSplitPreservesAllMinorUnits() {
+        val expense = expense(
+            amount = 100,
+            payerId = aliceId,
+            participantIds = listOf(bobId, charlieId),
+            weights = mapOf(bobId to 2, charlieId to 1),
+        )
+
+        val balances = calculator.calculateBalances(participants, listOf(expense))
+            .associate { it.participantId to it.amount.minorUnits }
+
+        assertEquals(100, balances.getValue(aliceId))
+        assertEquals(-67, balances.getValue(bobId))
+        assertEquals(-33, balances.getValue(charlieId))
+        assertEquals(0, balances.values.sum())
+    }
+
+    @Test
+    fun rejectsExpensesWithDifferentCurrencies() {
+        val first = expense(amount = 100, payerId = aliceId, participantIds = listOf(aliceId, bobId))
+        val second = expense(
+            id = ExpenseId("expense-2"),
+            amount = 100,
+            payerId = aliceId,
+            participantIds = listOf(aliceId, bobId),
+            currencyCode = "EUR",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            calculator.calculateBalances(participants, listOf(first, second))
+        }
+    }
+
+    @Test
+    fun rejectsUnbalancedInputWhenCalculatingDebts() {
+        assertFailsWith<IllegalArgumentException> {
+            calculator.calculateDebts(
+                listOf(
+                    Balance(aliceId, Money(100, "USD")),
+                    Balance(bobId, Money(-50, "USD")),
+                ),
+            )
+        }
+    }
+
+    private fun expense(
+        id: ExpenseId = expenseId,
+        amount: Long,
+        payerId: ParticipantId,
+        participantIds: List<ParticipantId>,
+        weights: Map<ParticipantId, Int> = emptyMap(),
+        currencyCode: String = "USD",
+    ): Expense {
+        return Expense(
+            id = id,
+            sessionId = sessionId,
+            title = "Expense",
+            amount = Money(amount, currencyCode),
+            payerId = payerId,
+            participantShares = participantIds.map { participantId ->
+                ExpenseParticipantShare(id, participantId, weights[participantId] ?: 1)
+            },
+            dateMillis = 1,
+            note = null,
+            createdAtMillis = 1,
+            updatedAtMillis = 1,
+        )
     }
 
     private fun participant(id: ParticipantId): Participant {


### PR DESCRIPTION
Objective: convert expenses into raw debts.

Deliverables:

- Balance calculator service.
- Deterministic rounding strategy.
- Domain unit tests for split scenarios.

Dependencies:

- Phase 5.

Estimated complexity: high.

Acceptance criteria:

- Partial expense participation works correctly.
- Sum of balances equals zero.
- Rounding never creates or loses minor units.
- Tests cover payer included and payer not included edge cases.

Open product decision:

- Should the payer be automatically included in participants involved, or can they pay for others without sharing?

Recommendation:

- Allow both, but default the payer as selected in the UI.